### PR TITLE
feat(surveys): ajouter téléchargement PDF pour formulaires complétés

### DIFF
--- a/.changeset/pdf-download-completed-forms.md
+++ b/.changeset/pdf-download-completed-forms.md
@@ -1,0 +1,13 @@
+---
+'@univ-lehavre/amarre': minor
+---
+
+Ajouter le téléchargement PDF pour les formulaires complétés
+
+- Ajouter l'endpoint API GET /api/v1/surveys/pdf pour télécharger le PDF d'un formulaire
+- Ajouter la fonction downloadSurveyPdf dans le service surveys
+- Ajouter fetchRedcapBuffer pour récupérer les données binaires depuis REDCap
+- Modifier Request.svelte pour afficher un lien de téléchargement PDF lorsque form_complete === '2'
+- Ajouter des tests pour valider le téléchargement PDF
+
+Lorsqu'un formulaire est complet (form_complete == "2"), le lien "Formulaire" devient "Formulaire (PDF)" et déclenche le téléchargement du PDF au lieu de rediriger vers REDCap.

--- a/src/lib/server/redcap/index.ts
+++ b/src/lib/server/redcap/index.ts
@@ -40,3 +40,11 @@ export const fetchRedcapText = async (params: Record<string, string>, context: {
   const response = await fetchRedcap(params, context);
   return response.text();
 };
+
+export const fetchRedcapBuffer = async (
+  params: Record<string, string>,
+  context: { fetch: Fetch },
+): Promise<ArrayBuffer> => {
+  const response = await fetchRedcap(params, context);
+  return response.arrayBuffer();
+};

--- a/src/lib/server/services/surveys.ts
+++ b/src/lib/server/services/surveys.ts
@@ -1,5 +1,5 @@
 import type { Fetch } from '$lib/types';
-import { fetchRedcapJSON, fetchRedcapText } from '$lib/server/redcap';
+import { fetchRedcapJSON, fetchRedcapText, fetchRedcapBuffer } from '$lib/server/redcap';
 import { ID } from 'node-appwrite';
 import type { TUser } from '$lib/types/api/user';
 import type { SurveyRequestItem } from '$lib/types/api/surveys';
@@ -123,5 +123,18 @@ export const fetchUserId = async (email: string, { fetch }: { fetch: Fetch }): P
   };
   const contacts: contactId[] = await fetchRedcapJSON<contactId[]>(requestData, { fetch });
   const result = contacts.length > 0 && contacts[0]?.userid ? contacts[0].userid : null;
+  return result;
+};
+
+/**
+ * Downloads the PDF of a form from REDCap for a given record ID.
+ *
+ * @param recordId - The record ID of the form to download
+ * @param context - An object providing a `fetch` implementation used to call the REDCap API
+ * @returns An ArrayBuffer containing the PDF data
+ */
+export const downloadSurveyPdf = async (recordId: string, context: { fetch: Fetch }): Promise<ArrayBuffer> => {
+  const requestData = { content: 'pdf', record: recordId, instrument: 'form', returnFormat: 'json' };
+  const result = await fetchRedcapBuffer(requestData, context);
   return result;
 };

--- a/src/lib/ui/Request.svelte
+++ b/src/lib/ui/Request.svelte
@@ -119,7 +119,15 @@
       </div>
     {/snippet}
     {#snippet links()}
-      {#if request.form}
+      {#if request.form_complete === '2'}
+        <!-- eslint-disable svelte/no-navigation-without-resolve -->
+        <a
+          href="/api/v1/surveys/pdf?record_id={request.record_id}"
+          class="card-link"
+          download="formulaire_{request.record_id}.pdf">Formulaire (PDF)</a
+        >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+      {:else if request.form}
         <!-- eslint-disable svelte/no-navigation-without-resolve -->
         <a
           href={request.form}

--- a/src/routes/api/v1/surveys/pdf/+server.ts
+++ b/src/routes/api/v1/surveys/pdf/+server.ts
@@ -1,0 +1,36 @@
+import type { RequestHandler } from './$types';
+import { downloadSurveyPdf } from '$lib/server/services/surveys';
+import { mapErrorToResponse } from '$lib/errors/mapper';
+import { json } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ locals, fetch, url }) => {
+  try {
+    const userId = locals.userId;
+    if (!userId) {
+      return json(
+        { data: null, error: { code: 'unauthenticated', message: 'No authenticated user' } },
+        { status: 401 },
+      );
+    }
+
+    const recordId = url.searchParams.get('record_id');
+    if (!recordId) {
+      return json(
+        { data: null, error: { code: 'invalid_request', message: 'Missing record_id parameter' } },
+        { status: 400 },
+      );
+    }
+
+    const pdfBuffer = await downloadSurveyPdf(recordId, { fetch });
+
+    return new Response(pdfBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="formulaire_${recordId}.pdf"`,
+      },
+    });
+  } catch (err) {
+    return mapErrorToResponse(err);
+  }
+};

--- a/tests/routes/api/v1/surveys/pdf.test.ts
+++ b/tests/routes/api/v1/surveys/pdf.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/services/surveys', () => ({ downloadSurveyPdf: vi.fn() }));
+
+describe('GET /api/v1/surveys/pdf', () => {
+  it('401 when unauthenticated', async () => {
+    const url = new URL('http://localhost/api/v1/surveys/pdf?record_id=test123');
+    const mod = await import('../../../../../src/routes/api/v1/surveys/pdf/+server');
+    const res = await mod.GET({ locals: {}, url, fetch: vi.fn() } as never);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+
+    expect(body).toMatchObject({ data: null, error: { code: 'unauthenticated', message: 'No authenticated user' } });
+  });
+
+  it('400 when record_id is missing', async () => {
+    const url = new URL('http://localhost/api/v1/surveys/pdf');
+    const mod = await import('../../../../../src/routes/api/v1/surveys/pdf/+server');
+    const res = await mod.GET({ locals: { userId: 'user_1' }, url, fetch: vi.fn() } as never);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+
+    expect(body).toMatchObject({
+      data: null,
+      error: { code: 'invalid_request', message: 'Missing record_id parameter' },
+    });
+  });
+
+  it('200 when downloading PDF successfully', async () => {
+    const services = await import('$lib/server/services/surveys');
+    const downloadSurveyPdf = services.downloadSurveyPdf as unknown as ReturnType<typeof vi.fn>;
+
+    const mockPdfBuffer = new ArrayBuffer(100);
+    downloadSurveyPdf.mockResolvedValue(mockPdfBuffer);
+
+    const url = new URL('http://localhost/api/v1/surveys/pdf?record_id=test123');
+    const mod = await import('../../../../../src/routes/api/v1/surveys/pdf/+server');
+    const res = await mod.GET({ locals: { userId: 'user_1' }, url, fetch: vi.fn() } as never);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+    expect(res.headers.get('Content-Disposition')).toContain('attachment');
+    expect(res.headers.get('Content-Disposition')).toContain('formulaire_test123.pdf');
+
+    const buffer = await res.arrayBuffer();
+    expect(buffer.byteLength).toBe(100);
+  });
+});


### PR DESCRIPTION
Lorsqu'un formulaire est validé (form_complete == "2"), le lien "Formulaire" permet maintenant de télécharger le PDF au lieu de rediriger vers REDCap.

Modifications:
- Ajouter endpoint GET /api/v1/surveys/pdf avec paramètre record_id
- Ajouter downloadSurveyPdf() dans services/surveys pour appeler REDCap
- Ajouter fetchRedcapBuffer() dans redcap/index pour données binaires
- Modifier Request.svelte pour afficher "Formulaire (PDF)" si form_complete === '2'
- Ajouter 3 tests pour valider l'endpoint (auth, paramètres, téléchargement)

L'endpoint appelle REDCap avec:
- content: 'pdf'
- record: record_id
- instrument: 'form'
- returnFormat: 'json'