### PR TITLE
feat(ui): auto-dismiss des alertes après 5 secondes

### DIFF
--- a/src/lib/ui/Signup.svelte
+++ b/src/lib/ui/Signup.svelte
@@ -6,7 +6,35 @@
 
   let email = $state('');
   let signuping = $state(false);
+  let showSuccessAlert = $state(false);
+  let showErrorAlert = $state(false);
   let disabledSubmit = $derived(!isEmail(email) || signuping ? 'disabled' : '');
+
+  $effect(() => {
+    if (form?.data) {
+      showSuccessAlert = true;
+      const timer = setTimeout(() => {
+        showSuccessAlert = false;
+        const modalElement = document.getElementById('SignUp');
+        if (modalElement) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const modal = (window as any).bootstrap?.Modal?.getInstance(modalElement);
+          modal?.hide();
+        }
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  });
+
+  $effect(() => {
+    if (form?.wrongSignupEmail) {
+      showErrorAlert = true;
+      const timer = setTimeout(() => {
+        showErrorAlert = false;
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  });
 </script>
 
 <div
@@ -91,7 +119,7 @@
             ></button>
           </div>
         {/if}
-        {#if form?.wrongSignupEmail}
+        {#if showErrorAlert && form?.wrongSignupEmail}
           <div
             class="alert alert-danger alert-dismissible fade show"
             role="alert"
@@ -102,12 +130,12 @@
             <button
               type="button"
               class="btn-close"
-              data-bs-dismiss="alert"
               aria-label="Close"
+              onclick={() => (showErrorAlert = false)}
             ></button>
           </div>
         {/if}
-        {#if form?.data}
+        {#if showSuccessAlert}
           <div
             class="alert alert-success alert-dismissible fade show"
             role="alert"
@@ -116,8 +144,8 @@
             <button
               type="button"
               class="btn-close"
-              data-bs-dismiss="alert"
               aria-label="Close"
+              onclick={() => (showSuccessAlert = false)}
             ></button>
           </div>
         {/if}


### PR DESCRIPTION
## Summary
- Les alertes de succès et d'erreur sur la page d'inscription disparaissent automatiquement après 5 secondes
- La modal se ferme également après la disparition de l'alerte de succès
- L'utilisateur peut toujours fermer manuellement les alertes via le bouton ✕

## Test plan
- [ ] Tester l'inscription avec un email valide → l'alerte de succès disparaît après 5 secondes et la modal se ferme
- [ ] Tester l'inscription avec un email invalide → l'alerte d'erreur disparaît après 5 secondes
- [ ] Vérifier que le bouton de fermeture manuelle fonctionne toujours

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)