### PR TITLE
feat(ui): refonte navigation avec sections Compléter, Suivre, Retrouver

### DIFF
--- a/src/lib/ui/Complete.svelte
+++ b/src/lib/ui/Complete.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import HorizontalScroller from '$lib/ui/HorizontalScroller.svelte';
+  import SectionTile from '$lib/ui/SectionTile.svelte';
+  import Request from './Request.svelte';
+
+  let { requests } = $props();
+  let showHeading = $state(false);
+</script>
+
+<div id="complete">
+  <HorizontalScroller
+    ariaLabel="Complete cards"
+    headingText="Compléter"
+    bind:showHeading
+  >
+    <SectionTile title={!showHeading ? 'Compléter' : ''} />
+    {#each requests as request (request.record_id)}
+      <Request {request} />
+    {/each}
+  </HorizontalScroller>
+</div>

--- a/src/lib/ui/Retrieve.svelte
+++ b/src/lib/ui/Retrieve.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import HorizontalScroller from '$lib/ui/HorizontalScroller.svelte';
+  import SectionTile from '$lib/ui/SectionTile.svelte';
+
+  let showHeading = $state(false);
+</script>
+
+<div id="retrieve">
+  <HorizontalScroller
+    ariaLabel="Retrieve cards"
+    headingText="Retrouver"
+    bind:showHeading
+  >
+    <SectionTile title={!showHeading ? 'Retrouver' : ''} />
+  </HorizontalScroller>
+</div>

--- a/src/lib/ui/TopNavbar.svelte
+++ b/src/lib/ui/TopNavbar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  let { hasRequests } = $props();
+  let { hasIncompleteRequests, hasRequestsInProgress } = $props();
   let navEl: HTMLElement | undefined;
 
   onMount(() => {
@@ -32,18 +32,40 @@
         ></i><span class="d-none d-md-inline">Déposer</span></a
       >
     </li>
-    {#if hasRequests}
+    {#if hasIncompleteRequests}
+      <li class="nav-item">
+        <a
+          class="nav-link"
+          href="#complete"
+          ><i
+            class="bi bi-pencil-square me-0 me-md-2"
+            aria-hidden="true"
+          ></i><span class="d-none d-md-inline">Compléter</span></a
+        >
+      </li>
+    {/if}
+    {#if hasRequestsInProgress}
       <li class="nav-item">
         <a
           class="nav-link"
           href="#follow"
           ><i
-            class="bi bi-people me-0 me-md-2"
+            class="bi bi-hourglass-split me-0 me-md-2"
             aria-hidden="true"
           ></i><span class="d-none d-md-inline">Suivre</span></a
         >
       </li>
     {/if}
+    <li class="nav-item">
+      <a
+        class="nav-link"
+        href="#retrieve"
+        ><i
+          class="bi bi-archive me-0 me-md-2"
+          aria-hidden="true"
+        ></i><span class="d-none d-md-inline">Retrouver</span></a
+      >
+    </li>
     <li class="nav-item">
       <a
         class="nav-link"


### PR DESCRIPTION
## Summary
- Sépare les demandes selon leur cycle de vie en 3 sections distinctes
- **Compléter** : demandes avec formulaire non finalisé (`form_complete != '2'`)
- **Suivre** : demandes en cours de validation (`form_complete == '2' && validation_finale_complete != '2'`)
- **Retrouver** : section placeholder pour les demandes archivées (vide pour l'instant)

## Test plan
- [ ] Vérifier que les onglets Compléter/Suivre s'affichent conditionnellement
- [ ] Vérifier que les demandes sont correctement triées dans chaque section
- [ ] Vérifier que la section Retrouver s'affiche (vide)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)