### PR TITLE
fix(api): limiter téléchargement aux instruments form et validation_finale

### DIFF
--- a/src/lib/server/services/surveys.ts
+++ b/src/lib/server/services/surveys.ts
@@ -27,6 +27,7 @@ export const downloadSurvey = async (userid: string, context: { fetch: Fetch }):
     rawOrLabel: 'label',
     rawOrLabelHeaders: 'label',
     exportCheckboxLabel: 'true',
+    forms: 'form,validation_finale',
   };
   const result = await fetchRedcapJSON<unknown>(requestData, context);
   return result;

--- a/tests/lib/server/services/surveys.test.ts
+++ b/tests/lib/server/services/surveys.test.ts
@@ -94,6 +94,23 @@ describe('surveys service - downloadSurvey', () => {
       expect.any(Object),
     );
   });
+
+  it('should limit export to form and validation_finale instruments', async () => {
+    const { downloadSurvey } = await import('$lib/server/services/surveys');
+    const { fetchRedcapJSON } = await import('$lib/server/redcap');
+    const mockFetchRedcapJSON = fetchRedcapJSON as unknown as ReturnType<typeof vi.fn>;
+
+    mockFetchRedcapJSON.mockResolvedValue([]);
+
+    const mockFetch = vi.fn() as unknown as Fetch;
+    await downloadSurvey('user123', { fetch: mockFetch });
+
+    // Verify that forms parameter limits to form and validation_finale
+    expect(mockFetchRedcapJSON).toHaveBeenCalledWith(
+      expect.objectContaining({ forms: 'form,validation_finale' }),
+      expect.any(Object),
+    );
+  });
 });
 
 describe('surveys service - listRequests', () => {


### PR DESCRIPTION
## Summary
- Limite l'export des données de surveys aux seuls instruments `form` et `validation_finale`
- Empêche l'accès aux données sensibles des autres instruments lors du téléchargement

Closes #79

## Test plan
- [x] Test unitaire ajouté pour vérifier le paramètre `forms`
- [x] Tester manuellement le téléchargement et vérifier que seuls les champs de `form` et `validation_finale` sont présents

🤖 Generated with [Claude Code](https://claude.com/claude-code)