### PR TITLE
feat(ui): add alternating background colors to sections

### DIFF
--- a/src/lib/ui/Administrate.svelte
+++ b/src/lib/ui/Administrate.svelte
@@ -15,6 +15,7 @@
     ariaLabel="Administrate cards"
     headingText="Administrate"
     bind:showHeading
+    variant="dark"
   >
     <SectionTile title={!showHeading ? 'Administrer' : ''} />
 

--- a/src/lib/ui/Collaborate.svelte
+++ b/src/lib/ui/Collaborate.svelte
@@ -22,6 +22,7 @@
     ariaLabel="Collaborate cards"
     headingText="Collaborate"
     bind:showHeading
+    variant="light"
   >
     <SectionTile title={!showHeading ? 'Déposer' : ''} />
     <div class="flex-shrink-0">

--- a/src/lib/ui/Complete.svelte
+++ b/src/lib/ui/Complete.svelte
@@ -12,6 +12,7 @@
     ariaLabel="Complete cards"
     headingText="Compléter"
     bind:showHeading
+    variant="dark"
   >
     <SectionTile title={!showHeading ? 'Compléter' : ''} />
     {#each requests as request (request.record_id)}

--- a/src/lib/ui/Follow.svelte
+++ b/src/lib/ui/Follow.svelte
@@ -12,6 +12,7 @@
     ariaLabel="Follow cards"
     headingText="Suivre"
     bind:showHeading
+    variant="light"
   >
     <SectionTile title={!showHeading ? 'Suivre' : ''} />
     {#each requests as request (request.record_id)}

--- a/src/lib/ui/Footer.svelte
+++ b/src/lib/ui/Footer.svelte
@@ -7,7 +7,7 @@
   ];
 </script>
 
-<footer class="footer mt-5 py-4">
+<footer class="footer py-4">
   <div class="container">
     <div class="d-flex justify-content-center align-items-center gap-4 flex-wrap">
       {#each logos as logo (logo.src)}
@@ -23,8 +23,7 @@
 
 <style>
   .footer {
-    border-top: 1px solid #dee2e6;
-    background-color: #f8f9fa;
+    background-color: transparent;
   }
 
   .logo {

--- a/src/lib/ui/HorizontalScroller.svelte
+++ b/src/lib/ui/HorizontalScroller.svelte
@@ -12,6 +12,7 @@
     headingText?: string; // titre à afficher en <h1> quand la tuile-titre disparaît
     headingRatio?: number; // ratio de visibilité sous lequel on affiche le header (0..1)
     showHeading?: boolean; // bindable: reflète l'état d'affichage du header
+    variant?: 'light' | 'dark' | 'none'; // alternance de couleurs basée sur info
   }
   let {
     ariaLabel = 'Horizontal scroller',
@@ -22,6 +23,7 @@
     headingText,
     headingRatio = 0.85,
     showHeading = $bindable(false),
+    variant = 'none',
   }: Props = $props();
 
   let scroller: HTMLDivElement;
@@ -72,60 +74,76 @@
   });
 </script>
 
-{#if headingText && showHeading}
-  <div
-    class="fw-bolder fs-3 mb-2"
-    style="font-family: Gambetta;"
-  >
-    {headingText}
-  </div>
-{/if}
+<div class="hs-wrapper {variant !== 'none' ? `hs-${variant}` : ''}">
+  <div class="container">
+    {#if headingText && showHeading}
+      <div
+        class="fw-bolder fs-3 mb-2"
+        style="font-family: Gambetta;"
+      >
+        {headingText}
+      </div>
+    {/if}
 
-<div class="position-relative hs-root">
-  <div
-    class={`overflow-auto ${snap !== 'none' ? 'snap-x' : ''}`}
-    style={`scroll-padding-inline: ${snapPadding}`}
-    aria-label={ariaLabel}
-    bind:this={scroller}
-    onscroll={updateArrows}
-  >
-    <div
-      class={`d-flex flex-column flex-sm-row flex-sm-nowrap pe-3 py-1 ${snap !== 'none' ? 'snap-items' : ''}`}
-      style={(snap !== 'none' ? `--snap-align: ${snap}; ` : '') + `gap: var(--card-gap, 1rem);`}
-      bind:this={items}
-    >
-      {@render children?.()}
+    <div class="position-relative hs-root">
+      <div
+        class={`overflow-auto ${snap !== 'none' ? 'snap-x' : ''}`}
+        style={`scroll-padding-inline: ${snapPadding}`}
+        aria-label={ariaLabel}
+        bind:this={scroller}
+        onscroll={updateArrows}
+      >
+        <div
+          class={`d-flex flex-column flex-sm-row flex-sm-nowrap pe-3 py-1 ${snap !== 'none' ? 'snap-items' : ''}`}
+          style={(snap !== 'none' ? `--snap-align: ${snap}; ` : '') + `gap: var(--card-gap, 1rem);`}
+          bind:this={items}
+        >
+          {@render children?.()}
+        </div>
+      </div>
+
+      {#if showLeft || showRight}
+        <div
+          class="position-absolute top-50 end-0 translate-middle-y pe-2 d-flex flex-column align-items-end hs-arrows d-none d-sm-flex"
+          style="z-index: 2;"
+        >
+          {#if showLeft}
+            <button
+              class="btn btn-light btn-sm shadow mb-2"
+              aria-label="Scroll left"
+              onclick={() => scrollStep(-1)}
+            >
+              <i class="bi bi-chevron-left"></i>
+            </button>
+          {/if}
+          {#if showRight}
+            <button
+              class="btn btn-light btn-sm shadow"
+              aria-label="Scroll right"
+              onclick={() => scrollStep(1)}
+            >
+              <i class="bi bi-chevron-right"></i>
+            </button>
+          {/if}
+        </div>
+      {/if}
     </div>
   </div>
-
-  {#if showLeft || showRight}
-    <div
-      class="position-absolute top-50 end-0 translate-middle-y pe-2 d-flex flex-column align-items-end hs-arrows d-none d-sm-flex"
-      style="z-index: 2;"
-    >
-      {#if showLeft}
-        <button
-          class="btn btn-light btn-sm shadow mb-2"
-          aria-label="Scroll left"
-          onclick={() => scrollStep(-1)}
-        >
-          <i class="bi bi-chevron-left"></i>
-        </button>
-      {/if}
-      {#if showRight}
-        <button
-          class="btn btn-light btn-sm shadow"
-          aria-label="Scroll right"
-          onclick={() => scrollStep(1)}
-        >
-          <i class="bi bi-chevron-right"></i>
-        </button>
-      {/if}
-    </div>
-  {/if}
 </div>
 
 <style>
+  /* Wrapper pleine largeur avec couleur de fond */
+  .hs-wrapper {
+    width: 100%;
+    padding: 1rem 0;
+  }
+  /* Variantes de couleur basées sur info */
+  .hs-light {
+    background-color: rgba(var(--bs-info-rgb), 0.07);
+  }
+  .hs-dark {
+    background-color: rgba(var(--bs-info-rgb), 0.12);
+  }
   /* Les enfants attendus: items avec .flex-shrink-0 (cartes de 18rem) */
   .snap-x {
     scroll-snap-type: x mandatory;

--- a/src/lib/ui/TopNavbar.svelte
+++ b/src/lib/ui/TopNavbar.svelte
@@ -18,7 +18,7 @@
 
 <nav
   id="navbar1"
-  class="navbar sticky-top bg-body px-3 mb-3 justify-content-center"
+  class="navbar sticky-top px-3 mb-3 justify-content-center bg-transparent"
   bind:this={navEl}
 >
   <ul class="nav nav-tabs justify-content-center">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,6 @@
   import Administrate from '$lib/ui/Administrate.svelte';
   import ECRIN from '$lib/ui/MainTitle.svelte';
   import TopNavbar from '$lib/ui/TopNavbar.svelte';
-  import Rule from '$lib/ui/Rule.svelte';
   import Follow from '$lib/ui/Follow.svelte';
   import Footer from '$lib/ui/Footer.svelte';
 
@@ -15,8 +14,6 @@
 
   const userId = $derived(data.user?.id);
   const email = $derived(data.user?.email);
-
-  let containerClass = $state<'container' | 'container-fluid' | 'container-fluid w-75'>('container');
 
   // Demandes avec formulaire non finalisé (form_complete != '2')
   let incompleteRequests = $derived(
@@ -39,32 +36,27 @@
   {hasRequestsInProgress}
 />
 
-<div class={containerClass}>
-  <div
-    data-bs-spy="scroll"
-    data-bs-target="#navbar1"
-    data-bs-root-margin="0px 0px -50%"
-    data-bs-smooth-scroll="true"
-  >
-    <Collaborate
-      {userId}
-      requests={data.requests}
-    />
-    <Rule />
-    {#if hasIncompleteRequests}
-      <Complete requests={incompleteRequests} />
-      <Rule />
-    {/if}
-    {#if hasRequestsInProgress}
-      <Follow requests={requestsInProgress} />
-      <Rule />
-    {/if}
-    <Administrate
-      {userId}
-      {email}
-      {form}
-    />
-  </div>
+<div
+  data-bs-spy="scroll"
+  data-bs-target="#navbar1"
+  data-bs-root-margin="0px 0px -50%"
+  data-bs-smooth-scroll="true"
+>
+  <Collaborate
+    {userId}
+    requests={data.requests}
+  />
+  {#if hasIncompleteRequests}
+    <Complete requests={incompleteRequests} />
+  {/if}
+  {#if hasRequestsInProgress}
+    <Follow requests={requestsInProgress} />
+  {/if}
+  <Administrate
+    {userId}
+    {email}
+    {form}
+  />
 </div>
 
 <Footer />

--- a/static/theme.css
+++ b/static/theme.css
@@ -3,6 +3,10 @@
  * Adapte les couleurs primary et warning aux couleurs du logo AMARRE
  */
 
+body {
+  background-color: rgba(10, 126, 164, 0.05);
+}
+
 :root {
   /* Couleur primaire (bleu marine du logo AMARRE) */
   --bs-primary: #0c4e6a;


### PR DESCRIPTION
## Summary
- Add full-width wrapper with info-based color variants to HorizontalScroller
- Set body background to 5% info opacity as base color
- Alternate sections between light (7%) and dark (12%) variants
- Make navbar and footer transparent to show base background
- Remove Rule separators and spacing between sections

## Test plan
- [x] Verify alternating colors display correctly on sections
- [x] Check navbar and footer have transparent background
- [x] Test responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)